### PR TITLE
Use std algorithms to replace raw loops

### DIFF
--- a/cpp/src/io/shp/polygon_shapefile_reader.cpp
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cpp
@@ -30,6 +30,9 @@
 
 namespace {
 
+// TODO: a better approach is to precompute the total size needed by xs and ys
+// as a preprocess and preallocate xs, ys. `read_ring` should simply accept
+// an iterator range and return the pass-the-end iterator.
 cudf::size_type read_ring(OGRLinearRing const& ring,
                           std::vector<double>& xs,
                           std::vector<double>& ys,


### PR DESCRIPTION
As title. I think a general better way to do this is to precompute the size of xs and ys in a pre-traversal run and pre-allocate everything we needed. The current approach is susceptive to infrequent data moves. But that requires a much larger refactor than it currently is. We can punt till later but add a TODO here.