### PR TITLE
User guide: refactor spatial join section for clarity, correct some capitalization / function spelling

### DIFF
--- a/docs/source/api_docs/geopandas_compatibility.rst
+++ b/docs/source/api_docs/geopandas_compatibility.rst
@@ -3,8 +3,8 @@ GeoPandas Compatibility
 
 cuSpatial supports any geometry format supported by `GeoPandas`. Load geometry information from a `GeoPandas.GeoSeries` or `GeoPandas.GeoDataFrame`.
 
-    >>> gpdf = geopandas.read_file('arbitrary.txt')
-        cugpdf = cuspatial.from_geopandas(gpdf)
+    >>> host_dataframe = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+        cugpdf = cuspatial.from_geopandas(host_dataframe)
 
 or
 

--- a/docs/source/user_guide/users.ipynb
+++ b/docs/source/user_guide/users.ipynb
@@ -32,8 +32,7 @@
     "* [Projection](#Projection)\n",
     "* [Distance](#Distance)\n",
     "* [Filtering](#Filtering)\n",
-    "* [Spatial joins](#Spatial-joins)\n",
-    "  * [Indexing](#Indexing)"
+    "* [Spatial joins](#Spatial-joins)"
    ]
   },
   {
@@ -1033,18 +1032,15 @@
    "source": [
     "## Spatial Joins\n",
     "\n",
-    "cuSpatial provides a number of functions to facilitate spatial joins, \n",
+    "cuSpatial provides a number of functions to facilitate high-performance spatial joins, \n",
     "including unindexed and quadtree-indexed point-in-polygon and quadtree-indexed point to nearest\n",
     "linestring.\n",
     "\n",
-    "### Unindexed Join\n",
+    "The API for spatial joins does not yet match GeoPandas, but with knowledge of cuSpatial data formats\n",
+    "you can call  `cuspatial.point_in_polygon` for large numbers of points on 32 polygons or less, or\n",
+    "call `cuspatial.quadtree_point_in_polygon` for large numbers of points and polygons.  \n",
     "\n",
-    "cuSpatial supports high-performance spatial joins. The API for spatial joins does not \n",
-    "yet match GeoPandas, but with knowledge of cuSpatial data formats you can call  \n",
-    "`cuspatial.point_in_polygon` for large numbers of points on 32 polygons or less, or call  \n",
-    "`cuspatial.quadtree_point_in_polygon` for large numbers of points and polygons.  \n",
-    "\n",
-    "See the example in [Indexing](#Indexing) to use ``.\n",
+    "### Unindexed Point-in-polygon Join\n",
     "\n",
     "### [cuspatial.point_in_polygon](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.point_in_polygon)"
    ]
@@ -1090,7 +1086,7 @@
    "id": "387565b3-75ae-4789-a950-daffc2d4da01",
    "metadata": {},
    "source": [
-    "### Indexing\n",
+    "### Quadtree Indexing\n",
     "\n",
     "The indexing module is used to create a spatial quadtree. Use  \n",
     "```\n",
@@ -1185,10 +1181,12 @@
    "id": "0ab7e64d-1199-498c-b020-b3e7393337a5",
    "metadata": {},
    "source": [
-    "### Indexed Joining\n",
+    "### Indexed Spatial Joins\n",
     "\n",
-    "The quadtree spatial index (`point_indices` and `quadtree`) are used by `quadtree_point_in_polygon`\n",
-    "to accelerate larger spatial joins. `quadtree_point_in_polygon` depends on a number of intermediate products calculated here using the following functions.\n",
+    "The quadtree spatial index (`point_indices` and `quadtree`) is used by `quadtree_point_in_polygon`\n",
+    "and `quadtree_point_to_nearest_polyline` to accelerate larger spatial joins. \n",
+    "`quadtree_point_in_polygon` depends on a number of intermediate products calculated here using the\n",
+    "following functions.\n",
     "\n",
     "### [cuspatial.polygon_bounding_boxes](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.polygon_bounding_boxes)\n",
     "### [cuspatial.join_quadtree_and_bounding_boxes](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.join_quadtree_and_bounding_boxes)\n",

--- a/docs/source/user_guide/users.ipynb
+++ b/docs/source/user_guide/users.ipynb
@@ -5,10 +5,10 @@
    "id": "c5fdf490-fa77-4e56-92d1-53101fff75ba",
    "metadata": {},
    "source": [
-    "# cuspatial Python User's Guide\n",
+    "# cuSpatial Python User's Guide\n",
     "\n",
-    "cuspatial is a GPU-accelerated Python library for spatial data analysis including distance and  \n",
-    "trajectory computations, spatial data indexing and spatial join operations. cuspatial's  \n",
+    "cuSpatial is a GPU-accelerated Python library for spatial data analysis including distance and  \n",
+    "trajectory computations, spatial data indexing and spatial join operations. cuSpatial's  \n",
     "Python API provides an accessible interface to high-performance spatial algorithms accelerated\n",
     "by CUDA-enabled GPUs."
    ]
@@ -20,10 +20,10 @@
    "source": [
     "## Contents\n",
     "\n",
-    "This guide provides a working example for all of the python API components of cuspatial.  \n",
+    "This guide provides a working example for all of the python API components of cuSpatial.  \n",
     "The following list links to each subsection.\n",
     "\n",
-    "* [Installing cuspatial](#Installing-cuspatial)\n",
+    "* [Installing cuSpatial](#Installing-cuspatial)\n",
     "* [GPU accelerated memory layout](#GPU-accelerated-memory-layout)\n",
     "* [Input / Output](#Input-/-Output)\n",
     "* [Geopandas and cuDF integration](#Geopandas-and-cuDF-integration)\n",
@@ -41,11 +41,11 @@
    "id": "115c8382-f83f-476f-9a26-a64a45b3a8da",
    "metadata": {},
    "source": [
-    "## Installing cuspatial\n",
-    "Read the [RAPIDS Quickstart Guide](  https://rapids.ai/start.html     ) to learn more about installing all RAPIDS libraries, including cuspatial.\n",
+    "## Installing cuSpatial\n",
+    "Read the [RAPIDS Quickstart Guide](  https://rapids.ai/start.html     ) to learn more about installing all RAPIDS libraries, including cuSpatial.\n",
     "\n",
     "If you are working on a system with a CUDA-enabled GPU and have CUDA installed, uncomment the  \n",
-    "following cell and install cuspatial:"
+    "following cell and install cuSpatial:"
    ]
   },
   {
@@ -67,7 +67,7 @@
     "For other options to create a RAPIDS environment, such as docker or build from source, see  \n",
     "[RAPIDS Release Selector](  https://rapids.ai/start.html#get-rapids). \n",
     "\n",
-    "If you wish to contribute to cuspatial, you should create a source build using the excellent [rapids-compose](https://github.com/trxcllnt/rapids-compose)"
+    "If you wish to contribute to cuSpatial, you should create a source build using the excellent [rapids-compose](https://github.com/trxcllnt/rapids-compose)"
    ]
   },
   {
@@ -77,9 +77,9 @@
    "source": [
     "## GPU accelerated memory layout\n",
     "\n",
-    "cuspatial uses `GeoArrow` buffers, a GPU-friendly data format for geometric data that is well  \n",
+    "cuSpatial uses `GeoArrow` buffers, a GPU-friendly data format for geometric data that is well  \n",
     "suited for massively parallel programming. See [I/O](#io) on the fastest methods to get your  \n",
-    "data into cuspatial. GeoArrow extends [PyArrow](\n",
+    "data into cuSpatial. GeoArrow extends [PyArrow](\n",
     "https://arrow.apache.org/docs/python/index.html       ) bindings and introduces several new types suited  \n",
     "for geometry applications.  GeoArrow supports [ListArrays](\n",
     "https://arrow.apache.org/docs/python/data.html#arrays) for `Points`, `MultiPoints`,  \n",
@@ -99,7 +99,7 @@
    "source": [
     "## Input / Output\n",
     "\n",
-    "cuspatial supports two modes of loading Feature coordinates. [cuspatial.read_polygon_shapefile](\n",
+    "cuSpatial supports two modes of loading Feature coordinates. [cuspatial.read_polygon_shapefile](\n",
     "https://docs.rapids.ai/api/cuspatial/stable/api_docs/io.html#cuspatial.read_polygon_shapefile)  \n",
     "and [cuspatial.from_geopandas](\n",
     "https://docs.rapids.ai/api/cuspatial/stable/api_docs/io.html?highlight=from_geopandas#cuspatial.from_geopandas).\n",
@@ -112,7 +112,7 @@
     "`cuspatial.read_polygon_shapefile` loads a `Polygon`-only shapefile from disk. It uses GPU acceleration and  \n",
     "can read hundreds of megabytes of `Polygon` information in milliseconds.\n",
     "\n",
-    "Examples of cuspatial's I/O functionality in the below cells:"
+    "Examples of cuSpatial's I/O functionality in the below cells:"
    ]
   },
   {
@@ -221,7 +221,7 @@
    "source": [
     "### [cuspatial.from_geopandas](https://docs.rapids.ai/api/cuspatial/stable/api_docs/io.html?highlight=from_geopandas#cuspatial.from_geopandas)\n",
     "\n",
-    "If you need other geometry types, the easiest way to get data into cuspatial is via\n",
+    "If you need other geometry types, the easiest way to get data into cuSpatial is via\n",
     "`cuspatial.from_geopandas`."
    ]
   },
@@ -268,7 +268,7 @@
    "source": [
     "## Geopandas and cuDF integration\n",
     "\n",
-    "A cuspatial [GeoDataFrame](\n",
+    "A cuSpatial [GeoDataFrame](\n",
     "https://docs.rapids.ai/api/cuspatial/stable/api_docs/geopandas_compatibility.html#cuspatial.GeoDataFrame               ) is a collection of [cudf](\n",
     "https://docs.rapids.ai/api/cudf/stable/              ) [Series](\n",
     "https://docs.rapids.ai/api/cudf/stable/api_docs/series.html    ) and\n",
@@ -277,8 +277,8 @@
     "Both types of series are stored on the GPU, and\n",
     "`GeoSeries` is represented internally using `GeoArrow` data layout.\n",
     "\n",
-    "One of the most important features of cuspatial is that it is highly integrated with `cuDF`.  \n",
-    "You can use any `cuDF` operation on cuspatial non-feature columns, and most operations will work  \n",
+    "One of the most important features of cuSpatial is that it is highly integrated with `cuDF`.  \n",
+    "You can use any `cuDF` operation on cuSpatial non-feature columns, and most operations will work  \n",
     "with a `geometry` column. Operations that reduce or collate the number of rows in your DataFrame,  \n",
     "for example `groupby`, are not supported at this time."
    ]
@@ -640,7 +640,7 @@
    "source": [
     "## Projection\n",
     "\n",
-    "cuspatial provides a simple sinusoidal longitude / latitude to Cartesian coordinate transform.  \n",
+    "cuSpatial provides a simple sinusoidal longitude / latitude to Cartesian coordinate transform.  \n",
     "This function requires an origin point to determine the scaling parameters for the lonlat inputs.  \n",
     "\n",
     "### [cuspatial.lonlat_to_cartesian](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.lonlat_to_cartesian)\n",
@@ -698,7 +698,7 @@
     "of input geometries (for each input geometry in A, compute the distance from A to each input\n",
     "geometry in B).\"\n",
     "    \n",
-    "Two pairwise distance functions are included in cuspatial: `haversine` and `pairwise_linestring`.  \n",
+    "Two pairwise distance functions are included in cuSpatial: `haversine` and `pairwise_linestring`.  \n",
     "The `hausdorff` clustering distances algorithm is also available, computing the hausdorff  \n",
     "distance across the cartesian product of its single input.\n",
     "\n",
@@ -769,7 +769,7 @@
    "source": [
     "### [cuspatial.haversine_distance](https://docs.rapids.ai/api/cuspatial/stable/api_docs/gis.html#cuspatial.haversine_distance)\n",
     "\n",
-    "Haversine distance is the great circle distance between longitude and latitude pairs. cuspatial  \n",
+    "Haversine distance is the great circle distance between longitude and latitude pairs. cuSpatial  \n",
     "uses the `lon/lat` ordering to better reflect the cartesian coordinates of great circle  \n",
     "coordinates: `x/y`.\n",
     "\n",
@@ -1280,8 +1280,8 @@
    "source": [
     "## Unindexed Join\n",
     "\n",
-    "cuspatial supports high-performance spatial joins. The API surface for spatial joins does  \n",
-    "not yet map to GeoPandas, but with knowledge of cuspatial data formats you can call  \n",
+    "cuSpatial supports high-performance spatial joins. The API surface for spatial joins does  \n",
+    "not yet map to GeoPandas, but with knowledge of cuSpatial data formats you can call  \n",
     "`cuspatial.point_in_polygon` for large numbers of points on 32 polygons or less, or call  \n",
     "`cuspatial.quadtree_point_in_polygon` for large numbers of points and polygons.  \n",
     "\n",
@@ -1337,7 +1337,7 @@
    "id": "b1ec002a-33a1-4ce4-8bbc-eba4800de5c6",
    "metadata": {},
    "source": [
-    "cuspatial includes another join algorithm, `point_in_polygon_quadtree` that uses an indexing  \n",
+    "cuSpatial includes another join algorithm, `point_in_polygon_quadtree` that uses an indexing  \n",
     "quadtree for faster calculations. `point_in_polygon_quadtree` also supports a number of  \n",
     "polygons limited only by memory constraints. "
    ]
@@ -1357,7 +1357,7 @@
    "id": "7286742e-a739-48f1-9ad5-8930155870a5",
    "metadata": {},
    "source": [
-    "cuspatial implements point-in-polygon and point-to-nearest-line-segment algorithms for spatial  \n",
+    "cuSpatial implements point-in-polygon and point-to-nearest-line-segment algorithms for spatial  \n",
     "joining. You can use these algorithms to implement many spatial-join needs. You can implement  \n",
     "these polygonal joins using only point-in-polygon:  \n",
     "\n",

--- a/docs/source/user_guide/users.ipynb
+++ b/docs/source/user_guide/users.ipynb
@@ -32,8 +32,8 @@
     "* [Projection](#Projection)\n",
     "* [Distance](#Distance)\n",
     "* [Filtering](#Filtering)\n",
-    "* [Indexing](#Indexing)\n",
-    "* [Spatial joins](#Spatial-joins)"
+    "* [Spatial joins](#Spatial-joins)\n",
+    "  * [Indexing](#Indexing)"
    ]
   },
   {
@@ -353,9 +353,7 @@
    "outputs": [
     {
      "data": {
-      "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"59.94324588403841 28.733388576771137 15.799965820375682 10.338076985718448\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,67.80485413926073)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.31599931640751366\" opacity=\"0.6\" d=\"M 66.51860680528867,37.36278432875879 L 67.07578209825962,37.35614390720929 L 67.82999962755952,37.144994004864685 L 68.13556237170138,37.02311513930431 L 68.85944583524594,37.344335842430596 L 69.19627282092438,37.15114350030743 L 69.51878543485796,37.60899669041342 L 70.11657840361033,37.58822276463209 L 70.27057417184014,37.735164699854025 L 70.3763041523093,38.13839590102752 L 70.80682050973289,38.486281643216415 L 71.34813113799026,38.25890534113216 L 71.23940392444817,37.953265082341886 L 71.54191775908478,37.905774441065645 L 71.44869347523024,37.06564484308052 L 71.8446382994506,36.73817129164692 L 72.1930408059624,36.948287665345674 L 72.63688968291729,37.047558091778356 L 73.26005577992501,37.495256862939 L 73.9486959166465,37.4215662704908 L 74.98000247589542,37.419990139305895 L 75.15802778514092,37.13303091078912 L 74.57589277537298,37.02084137628346 L 74.06755171091783,36.83617564548845 L 72.92002485544447,36.72000702569632 L 71.84629194528392,36.50994232842986 L 71.26234826038575,36.074387518857804 L 71.49876793812109,35.650563259416 L 71.61307620635071,35.153203436822864 L 71.11501875192164,34.733125718722235 L 71.15677330921346,34.34891144463215 L 70.8818030129884,33.98885590263852 L 69.9305432473596,34.02012014417511 L 70.3235941913716,33.35853261975839 L 69.68714725126486,33.105498969041236 L 69.26252200712256,32.5019440780883 L 69.31776411324256,31.901412258424443 L 68.92667687365767,31.620189113892067 L 68.55693200060932,31.713310044882018 L 67.79268924344478,31.58293040620963 L 67.68339358914747,31.30315420178142 L 66.93889122911847,31.304911200479353 L 66.38145755398602,30.738899237586452 L 66.34647260932442,29.887943427036177 L 65.0468620136161,29.472180691031905 L 64.35041873561852,29.560030625928093 L 64.14800215033125,29.340819200145972 L 63.55026085801117,29.468330796826166 L 62.54985680527278,29.31857249604431 L 60.87424848820879,29.829238999952608 L 61.781221551363444,30.735850328081238 L 61.69931440618083,31.379506130492672 L 60.94194461451113,31.548074652628753 L 60.863654819588966,32.18291962333443 L 60.536077915290775,32.98126882581157 L 60.963700392506006,33.52883230237626 L 60.52842980331158,33.676446031218006 L 60.80319339380745,34.40410187431986 L 61.210817091725744,35.650072333309225 L 62.230651483005886,35.270663967422294 L 62.98466230657661,35.40404083916762 L 63.19353844590035,35.857165635718914 L 63.98289594915871,36.0079574651466 L 64.5464791197339,36.31207326918427 L 64.7461051776774,37.111817735333304 L 65.58894778835784,37.30521678318564 L 65.74563073106683,37.66116404881207 L 66.21738488145934,37.39379018813392 L 66.51860680528867,37.36278432875879 z\" /></g></svg>"
-      ],
+      "image/svg+xml": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"59.94324588403841 28.733388576771137 15.799965820375682 10.338076985718448\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,67.80485413926073)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.31599931640751366\" opacity=\"0.6\" d=\"M 66.51860680528867,37.36278432875879 L 67.07578209825962,37.35614390720929 L 67.82999962755952,37.144994004864685 L 68.13556237170138,37.02311513930431 L 68.85944583524594,37.344335842430596 L 69.19627282092438,37.15114350030743 L 69.51878543485796,37.60899669041342 L 70.11657840361033,37.58822276463209 L 70.27057417184014,37.735164699854025 L 70.3763041523093,38.13839590102752 L 70.80682050973289,38.486281643216415 L 71.34813113799026,38.25890534113216 L 71.23940392444817,37.953265082341886 L 71.54191775908478,37.905774441065645 L 71.44869347523024,37.06564484308052 L 71.8446382994506,36.73817129164692 L 72.1930408059624,36.948287665345674 L 72.63688968291729,37.047558091778356 L 73.26005577992501,37.495256862939 L 73.9486959166465,37.4215662704908 L 74.98000247589542,37.419990139305895 L 75.15802778514092,37.13303091078912 L 74.57589277537298,37.02084137628346 L 74.06755171091783,36.83617564548845 L 72.92002485544447,36.72000702569632 L 71.84629194528392,36.50994232842986 L 71.26234826038575,36.074387518857804 L 71.49876793812109,35.650563259416 L 71.61307620635071,35.153203436822864 L 71.11501875192164,34.733125718722235 L 71.15677330921346,34.34891144463215 L 70.8818030129884,33.98885590263852 L 69.9305432473596,34.02012014417511 L 70.3235941913716,33.35853261975839 L 69.68714725126486,33.105498969041236 L 69.26252200712256,32.5019440780883 L 69.31776411324256,31.901412258424443 L 68.92667687365767,31.620189113892067 L 68.55693200060932,31.713310044882018 L 67.79268924344478,31.58293040620963 L 67.68339358914747,31.30315420178142 L 66.93889122911847,31.304911200479353 L 66.38145755398602,30.738899237586452 L 66.34647260932442,29.887943427036177 L 65.0468620136161,29.472180691031905 L 64.35041873561852,29.560030625928093 L 64.14800215033125,29.340819200145972 L 63.55026085801117,29.468330796826166 L 62.54985680527278,29.31857249604431 L 60.87424848820879,29.829238999952608 L 61.781221551363444,30.735850328081238 L 61.69931440618083,31.379506130492672 L 60.94194461451113,31.548074652628753 L 60.863654819588966,32.18291962333443 L 60.536077915290775,32.98126882581157 L 60.963700392506006,33.52883230237626 L 60.52842980331158,33.676446031218006 L 60.80319339380745,34.40410187431986 L 61.210817091725744,35.650072333309225 L 62.230651483005886,35.270663967422294 L 62.98466230657661,35.40404083916762 L 63.19353844590035,35.857165635718914 L 63.98289594915871,36.0079574651466 L 64.5464791197339,36.31207326918427 L 64.7461051776774,37.111817735333304 L 65.58894778835784,37.30521678318564 L 65.74563073106683,37.66116404881207 L 66.21738488145934,37.39379018813392 L 66.51860680528867,37.36278432875879 z\" /></g></svg>",
       "text/plain": [
        "<shapely.geometry.polygon.Polygon at 0x7ff64a790ca0>"
       ]
@@ -1030,10 +1028,69 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a17bd64a",
+   "metadata": {},
+   "source": [
+    "## Spatial Joins\n",
+    "\n",
+    "cuSpatial provides a number of functions to facilitate spatial joins, \n",
+    "including unindexed and quadtree-indexed point-in-polygon and quadtree-indexed point to nearest\n",
+    "linestring.\n",
+    "\n",
+    "### Unindexed Join\n",
+    "\n",
+    "cuSpatial supports high-performance spatial joins. The API for spatial joins does not \n",
+    "yet match GeoPandas, but with knowledge of cuSpatial data formats you can call  \n",
+    "`cuspatial.point_in_polygon` for large numbers of points on 32 polygons or less, or call  \n",
+    "`cuspatial.quadtree_point_in_polygon` for large numbers of points and polygons.  \n",
+    "\n",
+    "See the example in [Indexing](#Indexing) to use ``.\n",
+    "\n",
+    "### [cuspatial.point_in_polygon](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.point_in_polygon)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf7b2256",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "host_dataframe = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "gpu_dataframe = cuspatial.from_geopandas(host_dataframe)\n",
+    "x_points = (cupy.random.random(10000000) - 0.5) * 360\n",
+    "y_points = (cupy.random.random(10000000) - 0.5) * 180\n",
+    "\n",
+    "short_dataframe = gpu_dataframe.iloc[0:32]\n",
+    "geometry = short_dataframe['geometry']\n",
+    "points_in_polygon = cuspatial.point_in_polygon(\n",
+    "    x_points,\n",
+    "    y_points,\n",
+    "    geometry.polygons.geometry_offset[0:31],\n",
+    "    geometry.polygons.ring_offset,\n",
+    "    geometry.polygons.x,\n",
+    "    geometry.polygons.y\n",
+    ")\n",
+    "sum_of_points_in_polygons_0_to_31 = points_in_polygon.sum()\n",
+    "sum_of_points_in_polygons_0_to_31.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd9c4eef",
+   "metadata": {},
+   "source": [
+    "cuSpatial includes another join algorithm, `quadtree_point_in_polygon` that uses an indexing  \n",
+    "quadtree for faster calculations. `quadtree_point_in_polygon` also supports a number of  \n",
+    "polygons limited only by memory constraints."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "387565b3-75ae-4789-a950-daffc2d4da01",
    "metadata": {},
    "source": [
-    "## Indexing\n",
+    "### Indexing\n",
     "\n",
     "The indexing module is used to create a spatial quadtree. Use  \n",
     "```\n",
@@ -1130,9 +1187,8 @@
    "source": [
     "### Indexed Joining\n",
     "\n",
-    "These results `point_indices` and `quadtree` are used by `quadtree_point_in_polygon` for  \n",
-    "a more powerful method to compute point_in_polygon in most of the methods that it is useful.  \n",
-    "`quadtree_point_in_polygon` depends on a number of intermediate products that are calculated here:  \n",
+    "The quadtree spatial index (`point_indices` and `quadtree`) are used by `quadtree_point_in_polygon`\n",
+    "to accelerate larger spatial joins. `quadtree_point_in_polygon` depends on a number of intermediate products calculated here using the following functions.\n",
     "\n",
     "### [cuspatial.polygon_bounding_boxes](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.polygon_bounding_boxes)\n",
     "### [cuspatial.join_quadtree_and_bounding_boxes](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.join_quadtree_and_bounding_boxes)\n",
@@ -1275,88 +1331,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e0f1647-ba17-4d4e-885a-a6c09899ed4d",
-   "metadata": {},
-   "source": [
-    "## Unindexed Join\n",
-    "\n",
-    "cuSpatial supports high-performance spatial joins. The API surface for spatial joins does  \n",
-    "not yet map to GeoPandas, but with knowledge of cuSpatial data formats you can call  \n",
-    "`cuspatial.point_in_polygon` for large numbers of points on 32 polygons or less, or call  \n",
-    "`cuspatial.quadtree_point_in_polygon` for large numbers of points and polygons.  \n",
-    "\n",
-    "See the example in [Indexing](#Indexing) to use ``.\n",
-    "\n",
-    "### [cuspatial.point_in_polygon](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.point_in_polygon)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "e9836522-8a8e-4fe1-8687-4f8d2335259c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0       252\n",
-       "1     11679\n",
-       "2      1306\n",
-       "3    264202\n",
-       "4    172659\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "host_dataframe = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
-    "gpu_dataframe = cuspatial.from_geopandas(host_dataframe)\n",
-    "x_points = (cupy.random.random(10000000) - 0.5) * 360\n",
-    "y_points = (cupy.random.random(10000000) - 0.5) * 180\n",
-    "\n",
-    "short_dataframe = gpu_dataframe.iloc[0:32]\n",
-    "geometry = short_dataframe['geometry']\n",
-    "points_in_polygon = cuspatial.point_in_polygon(\n",
-    "    x_points,\n",
-    "    y_points,\n",
-    "    geometry.polygons.geometry_offset[0:31],\n",
-    "    geometry.polygons.ring_offset,\n",
-    "    geometry.polygons.x,\n",
-    "    geometry.polygons.y\n",
-    ")\n",
-    "sum_of_points_in_polygons_0_to_31 = points_in_polygon.sum()\n",
-    "sum_of_points_in_polygons_0_to_31.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b1ec002a-33a1-4ce4-8bbc-eba4800de5c6",
-   "metadata": {},
-   "source": [
-    "cuSpatial includes another join algorithm, `quadtree_point_in_polygon` that uses an indexing  \n",
-    "quadtree for faster calculations. `quadtree_point_in_polygon` also supports a number of  \n",
-    "polygons limited only by memory constraints. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "bfd94ac4-3b27-41f5-87dd-e00ae0291775",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "### cuspatial.quadtree_point_to_nearest_polyline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "7286742e-a739-48f1-9ad5-8930155870a5",
    "metadata": {},
    "source": [
+    "### Implementing other types of joins\n",
+    "\n",
     "cuSpatial implements point-in-polygon and point-to-nearest-line-segment algorithms for spatial  \n",
     "joining. You can use these algorithms to implement many spatial-join needs. You can implement  \n",
     "these polygonal joins using only point-in-polygon:  \n",
@@ -1364,7 +1343,7 @@
     "* Contains\n",
     "* Within\n",
     "\n",
-    "### Contains\n",
+    "#### Contains\n",
     "\n",
     "By keeping track of point ids it is possible to treat any geometry type as points and join using  \n",
     "point-in-polygon."
@@ -1580,7 +1559,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.10 64-bit ('rapids': conda)",
    "language": "python",
    "name": "python3"
   },
@@ -1594,7 +1573,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "095c3a7a10c98a819b882ee9fe096094f69a1e3586c68cd990c37b93fe693afd"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/users.ipynb
+++ b/docs/source/user_guide/users.ipynb
@@ -1130,9 +1130,9 @@
    "source": [
     "### Indexed Joining\n",
     "\n",
-    "These results `point_indices` and `quadtree` are used by `point_in_polygon_quadtree` for  \n",
+    "These results `point_indices` and `quadtree` are used by `quadtree_point_in_polygon` for  \n",
     "a more powerful method to compute point_in_polygon in most of the methods that it is useful.  \n",
-    "`point_in_polygon_quadtree` depends on a number of intermediate products that are calculated here:  \n",
+    "`quadtree_point_in_polygon` depends on a number of intermediate products that are calculated here:  \n",
     "\n",
     "### [cuspatial.polygon_bounding_boxes](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.polygon_bounding_boxes)\n",
     "### [cuspatial.join_quadtree_and_bounding_boxes](https://docs.rapids.ai/api/cuspatial/nightly/api_docs/spatial.html#cuspatial.join_quadtree_and_bounding_boxes)\n",
@@ -1337,8 +1337,8 @@
    "id": "b1ec002a-33a1-4ce4-8bbc-eba4800de5c6",
    "metadata": {},
    "source": [
-    "cuSpatial includes another join algorithm, `point_in_polygon_quadtree` that uses an indexing  \n",
-    "quadtree for faster calculations. `point_in_polygon_quadtree` also supports a number of  \n",
+    "cuSpatial includes another join algorithm, `quadtree_point_in_polygon` that uses an indexing  \n",
+    "quadtree for faster calculations. `quadtree_point_in_polygon` also supports a number of  \n",
     "polygons limited only by memory constraints. "
    ]
   },

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -133,7 +133,8 @@ class GeoDataFrame(cudf.DataFrame):
         """
         columns_mask = pd.Series(self.columns)
         geocolumn_mask = pd.Series(
-            [isinstance(self[col], GeoSeries) for col in self.columns]
+            [isinstance(self[col], GeoSeries) for col in self.columns],
+            dtype="bool",
         )
         geo_columns = self[columns_mask[geocolumn_mask]]
         # Send the rest of the columns to `cudf` to slice.

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -37,8 +37,11 @@ class GeoSeries(cudf.Series):
     stored in the `GeoArrowBuffers` object, accessible with the `points`,
     `multipoints`, `lines`, and `polygons` accessors.
 
-    >>> cuseries.points
-        xy:
+    >>> from shapely.geometry import Point
+        import geopandas
+        import cuspatial
+        cuseries = cuspatial.GeoSeries(geopandas.GeoSeries(Point(-1, 0)))
+        cuseries.points.xy
         0   -1.0
         1    0.0
         dtype: float64
@@ -422,8 +425,64 @@ class GeoSeries(cudf.Series):
             return results
 
     def to_arrow(self):
-        # Arrow can't view an empty list, so we need to prep the buffers
-        # here.
+        """
+        Convert to a GeoArrow Array.
+
+        Returns
+        -------
+        result: GeoArrow Union containing GeoArrow Arrays
+
+        Examples
+        --------
+        >>> from shapely.geometry import MultiLineString, LineString
+        >>> cugpdf = cuspatial.from_geopandas(geopandas.GeoSeries(
+            MultiLineString(
+                [
+                    [(1, 0), (0, 1)],
+                    [(0, 0), (1, 1)]
+                ]
+            )))
+        >>> cugpdf.to_arrow()
+        <pyarrow.lib.UnionArray object at 0x7f7061c0e0a0>
+        -- is_valid: all not null
+        -- type_ids:   [
+            2
+          ]
+        -- value_offsets:   [
+            0
+          ]
+        -- child 0 type: list<item: null>
+          []
+        -- child 1 type: list<item: null>
+          []
+        -- child 2 type: list<item: list<item: list<item: double>>>
+          [
+            [
+              [
+                [
+                  1,
+                  0
+                ],
+                [
+                  0,
+                  1
+                ]
+              ],
+              [
+                [
+                  0,
+                  0
+                ],
+                [
+                  1,
+                  1
+                ]
+              ]
+            ]
+          ]
+        -- child 3 type: list<item: null>
+          []
+        """
         points = self._column.points
         mpoints = self._column.mpoints
         lines = self._column.lines

--- a/python/cuspatial/cuspatial/core/spatial/distance.py
+++ b/python/cuspatial/cuspatial/core/spatial/distance.py
@@ -72,7 +72,7 @@ def directed_hausdorff_distance(xs, ys, space_offsets):
     >>> result = cuspatial.directed_hausdorff_distance(
             [0, 1, 0, 0], # xs
             [0, 0, 1, 2], # ys
-            [0, 2, 4],    # space_offsets
+            [0, 2],    # space_offsets
         )
     >>> print(result)
              0         1

--- a/python/cuspatial/cuspatial/core/trajectory.py
+++ b/python/cuspatial/cuspatial/core/trajectory.py
@@ -46,20 +46,20 @@ def derive_trajectories(object_ids, xs, ys, timestamps):
     Compute sorted objects and discovered trajectories
 
     >>> objects, traj_offsets = cuspatial.derive_trajectories(
-            [0, 1, 2, 3],  # object_id
+            [0, 1, 0, 1],  # object_id
             [0, 0, 1, 1],  # x
             [0, 0, 1, 1],  # y
-            [0, 10, 0, 10] # timestamp
+            [0, 10000, 0, 10000] # timestamp
         )
     >>> print(traj_offsets)
         0  0
         1  2
     >>> print(objects)
-           object_id       x       y  timestamp
-        0          0       1       0          0
-        1          0       0       0         10
-        2          1       3       1          0
-        3          1       2       1         10
+        object_id    x    y           timestamp
+        0          0  0.0  0.0 1970-01-01 00:00:00
+        1          0  1.0  1.0 1970-01-01 00:00:10
+        2          1  0.0  0.0 1970-01-01 00:00:00
+        3          1  1.0  1.0 1970-01-01 00:00:10
     """
 
     object_ids = as_column(object_ids, dtype=np.int32)
@@ -103,7 +103,7 @@ def trajectory_bounding_boxes(num_trajectories, object_ids, xs, ys):
     --------
     Compute the minimum bounding boxes of derived trajectories
 
-    >>> objects, traj_offsets = trajectory.derive_trajectories(
+    >>> objects, traj_offsets = cuspatial.derive_trajectories(
             [0, 0, 1, 1],  # object_id
             [0, 1, 2, 3],  # x
             [0, 0, 1, 1],  # y
@@ -168,10 +168,10 @@ def trajectory_distances_and_speeds(
             objects['timestamp']
         )
     >>> print(dists_and_speeds)
-                       distance          speed
+                          distance       speed
         trajectory_id
-        0                1000.0  100000.000000
-        1                1000.0  111111.109375
+        0              1414.213562  141.421356
+        1              1414.213562  141.421356
     """
 
     object_ids = as_column(object_ids, dtype=np.int32)


### PR DESCRIPTION
You can ignore the changes to everything but user.ipynb, as they come from merging 22.10 into my branch.

This PR
 - Refactors the sections on spatial joining and indexing to make the flow a bit more logical. I made Indexing part of this section rather than its own section. If we add other indexing methods in the future we can expand that section.
 - Corrects spelling of `quadtree_point_in_polygon`
 - Corrects capitalization of cuSpatial